### PR TITLE
Potential fix for code scanning alert no. 1: Request without certificate validation

### DIFF
--- a/src/targets/ruby/native/fixtures/insecure-skip-verify.rb
+++ b/src/targets/ruby/native/fixtures/insecure-skip-verify.rb
@@ -5,7 +5,7 @@ url = URI("https://mockbin.com/har")
 
 http = Net::HTTP.new(url.host, url.port)
 http.use_ssl = true
-http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
 request = Net::HTTP::Get.new(url)
 


### PR DESCRIPTION
Potential fix for [https://github.com/khulnasoft/httpsnippet/security/code-scanning/1](https://github.com/khulnasoft/httpsnippet/security/code-scanning/1)

To fix the problem, we need to ensure that the certificate validation is enabled by setting the `verify_mode` to `OpenSSL::SSL::VERIFY_PEER`. This change will ensure that the server's certificate is verified, making the connection secure.

The best way to fix the problem without changing existing functionality is to modify the `verify_mode` setting in the `Net::HTTP` object initialization. Specifically, we need to change line 8 in the file `src/targets/ruby/native/fixtures/insecure-skip-verify.rb`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fixes a code scanning alert related to requests without certificate validation by enabling certificate verification.